### PR TITLE
Clean up landing page copy and footer language

### DIFF
--- a/clawpoint-site/app/page.tsx
+++ b/clawpoint-site/app/page.tsx
@@ -271,7 +271,7 @@ export default function Home() {
 
                 <div className="flex-shrink-0 w-[160px] md:w-[200px]">
                   <div className="text-xs text-[var(--tactical-green-light)] font-mono tracking-widest mb-1" aria-hidden="true">
-                    CLEARANCE-02
+                    EXPERIENCE-02
                   </div>
                   <div className="text-3xl md:text-4xl font-bold text-[var(--night-vision)] font-mono leading-none relative">
                     24+
@@ -334,7 +334,7 @@ export default function Home() {
 
                 <div className="flex-shrink-0 w-[160px] md:w-[200px]">
                   <div className="text-xs text-[var(--tactical-green-light)] font-mono tracking-widest mb-1" aria-hidden="true">
-                    CLASSIFIED-04
+                    EXPERTISE-04
                   </div>
                   <div className="text-2xl md:text-3xl font-bold text-[var(--night-vision)] font-mono leading-tight relative">
                     CLEARED<br/>LEADERSHIP
@@ -358,50 +358,6 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Final CTA */}
-      <section className="relative py-10 px-4 sm:px-6 lg:px-8 bg-gradient-to-t from-black via-[var(--forest-depth-2)] to-black mt-16">
-        {/* Background image - light curves */}
-        <div className="absolute inset-0">
-          <Image
-            src="/images/AdobeStock_352206247.jpeg"
-            alt=""
-            fill
-            className="object-cover opacity-15 mix-blend-screen"
-          />
-        </div>
-
-        {/* Eyes watching */}
-        <div className="absolute inset-0 overflow-hidden pointer-events-none opacity-20">
-          {[
-            { left: '15%', top: '20%', gap: 6 },
-            { right: '20%', top: '30%', gap: 8 },
-            { left: '25%', bottom: '25%', gap: 5 },
-            { right: '30%', bottom: '35%', gap: 7 },
-          ].map((pos, i) => (
-            <div key={i} className={`absolute flex`} style={{...pos, gap: `${pos.gap * 4}px`}}>
-              <div className="w-2 h-2 bg-[var(--night-vision)] rounded-full eye-glow" />
-              <div className="w-2 h-2 bg-[var(--night-vision)] rounded-full eye-glow" />
-            </div>
-          ))}
-        </div>
-
-        <div className="max-w-5xl mx-auto text-center relative z-10">
-          <h2 className="heading-h2 text-white mb-5">
-            READY TO ENGAGE?
-          </h2>
-
-          <p className="text-lg md:text-xl text-gray-300 mb-12 font-mono leading-relaxed max-w-3xl mx-auto">
-            The threats are real. The Stakes are high. Your business cannot afford security gaps.
-            Let&apos;s eliminate them together.
-          </p>
-
-          <div className="pt-12 border-t border-[var(--tactical-green-dark)]">
-            <p className="text-sm text-gray-500 font-mono tracking-wider">
-              ENCRYPTED COMMUNICATION | SECURE BY DEFAULT | ALWAYS VIGILANT
-            </p>
-          </div>
-        </div>
-      </section>
     </div>
   )
 }

--- a/clawpoint-site/components/Footer.tsx
+++ b/clawpoint-site/components/Footer.tsx
@@ -49,18 +49,14 @@ export default function Footer() {
               </div>
             </Link>
             <p className="text-gray-400 font-mono text-sm leading-relaxed">
-              Hunting threats in the digital forest. Always vigilant. Always ready.
+              Protecting what matters most. Expert cybersecurity for modern threats.
             </p>
-            <div className="mt-4 flex items-center gap-2 text-night-vision/60 font-mono text-xs">
-              <span className="inline-block w-2 h-2 bg-night-vision rounded-full eye-glow animate-pulse" />
-              HUNTERS READY
-            </div>
           </div>
 
           {/* Contact Info */}
           <div>
             <h3 className="text-white font-mono font-bold text-sm tracking-wider uppercase mb-6 relative inline-block">
-              Contact Intel
+              Contact
               <span className="absolute -bottom-2 left-0 w-full h-0.5 bg-gradient-to-r from-night-vision to-transparent" />
             </h3>
             <ul className="space-y-4">
@@ -87,7 +83,7 @@ export default function Footer() {
           {/* Social & Security */}
           <div className="md:flex md:flex-col md:items-end">
             <h3 className="text-white font-mono font-bold text-sm tracking-wider uppercase mb-6 relative inline-block">
-              Tactical Links
+              Connect
               <span className="absolute -bottom-2 left-0 w-full h-0.5 bg-gradient-to-r from-night-vision to-transparent" />
             </h3>
             <div className="flex gap-3 mb-6">
@@ -121,7 +117,7 @@ export default function Footer() {
         {/* Tactical decoration */}
         <div className="mt-8 pt-8 border-t border-tactical-green-dark/50 flex items-center justify-center gap-4 text-tactical-green/20 font-mono text-xs">
           <span className="w-8 h-0.5 bg-gradient-to-r from-transparent to-tactical-green" />
-          <span>[ PREDATOR ACTIVE ]</span>
+          <span>[ SECURE ]</span>
           <span className="w-8 h-0.5 bg-gradient-to-l from-transparent to-tactical-green" />
         </div>
       </div>

--- a/clawpoint-site/tsconfig.json
+++ b/clawpoint-site/tsconfig.json
@@ -37,6 +37,7 @@
     "**/*.mts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "node_modules.old"
   ]
 }


### PR DESCRIPTION
## Summary

This PR removes overly militarized / covert-ops language from the landing page and footer, bringing the tone to security-focused without the heavy tactical framing.

### Homepage (`app/page.tsx`)

- **Removed the entire "Ready to Engage?" CTA section** at the bottom of the page. This section contained aggressive military framing ("The threats are real. The stakes are high."), the "Encrypted Communication | Secure by Default | Always Vigilant" tagline, and served no functional CTA purpose (no button).
- **Updated credential label copy:** `CLEARANCE-02` → `EXPERIENCE-02`, `CLASSIFIED-04` → `EXPERTISE-04`. These labels sit above the stats cards and were using security clearance / classified document terminology that leans too far into covert-ops territory.

### Footer (`components/Footer.tsx`)

- **"Tactical Links" → "Connect"** — section heading for the social/LinkedIn column
- **"Contact Intel" → "Contact"** — section heading for the contact info column
- **Footer tagline updated:** "Hunting threats in the digital forest. Always vigilant. Always ready." → "Protecting what matters most. Expert cybersecurity for modern threats."
- **Removed "Hunters Ready" status indicator** — the animated green dot with military-readiness label below the logo
- **Removed "[ Predator Active ]" decoration** — the bottom decorative text strip

### `tsconfig.json`

- Added `node_modules.old` to the TypeScript exclude list to prevent compilation errors from the legacy node_modules backup directory.

---

## ⚠️ Known Issue: Hero Background Video Missing in Production

The hero section references `/images/Reverse Video.mp4`, but this file has **never been committed to the repo** because it is **178MB** — over GitHub's 100MB file size limit. This is why the video background doesn't appear in production.

**The file needs to be hosted externally.** Recommended options:
- **Vercel Blob** — native to the deployment platform, easy integration
- **Cloudinary** — free tier, automatic video optimization and CDN delivery
- **AWS S3 + CloudFront** — if the project already uses AWS

Once hosted, update the `<source src="...">` in `app/page.tsx` hero section to point to the external URL.

## Test Plan

- [ ] Visit homepage and confirm "Ready to Engage?" section no longer appears at the bottom
- [ ] Confirm "Encrypted Communication" line is gone
- [ ] Check footer: headings read "Connect" and "Contact"
- [ ] Check footer tagline is updated
- [ ] Verify credential cards still display correctly (only label text changed)
- [ ] Confirm no TypeScript errors on build