### PR TITLE
Add Clear Signal doc link and improve Infinite View hero layout

### DIFF
--- a/clawpoint-site/app/infinite-view/page.tsx
+++ b/clawpoint-site/app/infinite-view/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
+import DownloadBrief from '@/components/DownloadBrief'
 
 export default function InfiniteViewPage() {
   const [scrollProgress, setScrollProgress] = useState(0)
@@ -28,7 +29,7 @@ export default function InfiniteViewPage() {
       </div>
 
       {/* Hero Section — logo + platform overview */}
-      <section className="relative flex items-center justify-center overflow-hidden">
+      <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
         <div className="absolute inset-0 opacity-5">
           <div className="absolute inset-0" style={{
             backgroundImage: 'linear-gradient(var(--tactical-green) 1px, transparent 1px), linear-gradient(90deg, var(--tactical-green) 1px, transparent 1px)',
@@ -50,7 +51,7 @@ export default function InfiniteViewPage() {
 
         <div className="relative z-10 px-4 sm:px-6 lg:px-8 max-w-6xl mx-auto w-full py-20 pt-28">
           {/* Logo — smaller */}
-          <div className="mb-10 iv-emerge flex justify-center">
+          <div className="mb-10 pt-12 pb-4 iv-emerge flex justify-center">
             <Image
               src="/images/New Infinite view.png"
               alt="Infinite View"
@@ -68,7 +69,7 @@ export default function InfiniteViewPage() {
               <span className="text-[var(--tactical-green-light)] font-mono text-xs tracking-widest">PLATFORM-01</span>
             </div>
             <h2 className="heading-h3 text-white mb-4">MODULAR ARCHITECTURE FOR MISSION SUCCESS</h2>
-            <p className="text-base md:text-lg text-gray-300 font-mono leading-relaxed">
+            <p className="text-base md:text-lg text-gray-300 font-mono leading-relaxed mb-24">
               Infinite View is Clawpoint&apos;s concept-stage analyst augmentation platform designed to reduce cognitive load and accelerate mission response by translating scattered security telemetry into a coherent operational picture. It is built to strengthen analyst judgment—not replace it.
             </p>
           </div>
@@ -164,6 +165,18 @@ export default function InfiniteViewPage() {
               </div>
             </article>
           </div>
+        </div>
+      </section>
+
+      {/* Clear Signal Purpose Document */}
+      <section className="relative border-t border-[var(--tactical-green-dark)] py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto">
+          <DownloadBrief
+            variant="banner"
+            title="CLEAR SIGNAL PURPOSE DOCUMENT"
+            hideLabel
+            href="/downloads/ClearSignal_Purpose_Document.html"
+          />
         </div>
       </section>
 

--- a/clawpoint-site/components/DownloadBrief.tsx
+++ b/clawpoint-site/components/DownloadBrief.tsx
@@ -7,9 +7,10 @@ interface DownloadBriefProps {
   className?: string
   title?: string
   hideLabel?: boolean
+  href?: string
 }
 
-export default function DownloadBrief({ variant = 'inline', className = '', title = 'CLAWPOINT SECURITY BRIEF', hideLabel = false }: DownloadBriefProps) {
+export default function DownloadBrief({ variant = 'inline', className = '', title = 'CLAWPOINT SECURITY BRIEF', hideLabel = false, href = 'https://acrobat.adobe.com/id/urn:aaid:sc:US:0c88d62e-687e-4e0f-89fb-ec14539bb34e' }: DownloadBriefProps) {
   const [isHovered, setIsHovered] = useState(false)
 
   if (variant === 'banner') {
@@ -39,7 +40,7 @@ export default function DownloadBrief({ variant = 'inline', className = '', titl
             {/* Right side - View button */}
             <div>
               <a
-                href="https://acrobat.adobe.com/id/urn:aaid:sc:US:0c88d62e-687e-4e0f-89fb-ec14539bb34e"
+                href={href}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-3 px-8 py-4 border-2 border-[var(--tactical-green)] bg-black hover:bg-[var(--tactical-green-dark)] hover:border-[var(--night-vision)] text-white font-mono font-bold text-sm tracking-wider transition-all duration-300 group-hover:scale-105 relative overflow-hidden"
@@ -82,7 +83,7 @@ export default function DownloadBrief({ variant = 'inline', className = '', titl
   // Inline variant - compact button
   return (
     <a
-      href="https://acrobat.adobe.com/id/urn:aaid:sc:US:0c88d62e-687e-4e0f-89fb-ec14539bb34e"
+      href={href}
       target="_blank"
       rel="noopener noreferrer"
       className={`inline-flex items-center gap-2 px-6 py-3 border-2 border-[var(--tactical-green)] bg-black hover:bg-[var(--tactical-green-dark)] hover:border-[var(--night-vision)] text-white font-mono font-bold text-sm tracking-wider transition-all duration-300 relative overflow-hidden group ${className}`}


### PR DESCRIPTION
Adds a Clear Signal Purpose Document banner link at the bottom of the Infinite View page using the existing DownloadBrief component. Also makes the hero section full-screen height with more padding around the logo and paragraph to push remaining content below the fold.