### PR TITLE
Comment out Clear Signal doc link on Infinite View page

### DIFF
--- a/clawpoint-site/app/about/page.tsx
+++ b/clawpoint-site/app/about/page.tsx
@@ -113,7 +113,7 @@ export default function AboutPage() {
                 { label: 'NAICS', value: '541512' },
                 { label: 'NAICS', value: '541611' },
                 { label: 'NAICS', value: '561690' },
-                { label: 'NAICS', value: '541690' },
+                { label: 'NAICS', value: '541990' },
                 { label: 'UEI', value: 'QMGUKY66AD53' },
                 { label: 'CAGE', value: '8P5B8' },
                 { label: null, value: 'SDVOSB' },

--- a/clawpoint-site/app/infinite-view/page.tsx
+++ b/clawpoint-site/app/infinite-view/page.tsx
@@ -169,7 +169,7 @@ export default function InfiniteViewPage() {
       </section>
 
       {/* Clear Signal Purpose Document */}
-      <section className="relative border-t border-[var(--tactical-green-dark)] py-12 px-4 sm:px-6 lg:px-8">
+      {/* <section className="relative border-t border-[var(--tactical-green-dark)] py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-4xl mx-auto">
           <DownloadBrief
             variant="banner"
@@ -178,7 +178,7 @@ export default function InfiniteViewPage() {
             href="/downloads/ClearSignal_Purpose_Document.html"
           />
         </div>
-      </section>
+      </section> */}
 
     </div>
   )


### PR DESCRIPTION
Temporarily comments out the Clear Signal Purpose Document banner section so it is hidden from the live site but easy to restore.